### PR TITLE
Fix BeaverTails license

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -1103,7 +1103,7 @@
 
 - Language(s): English
 - Source(s): Human-AI conversations / manually labelled
-- License: `MIT`
+- License: `CC BY-NC 4.0`
 - Alias: `beaver_tails_330k`
 
 <details>


### PR DESCRIPTION
BeaverTails appears to be license as `CC BY-NC 4.0`. See their HuggingFace page for the dataset: https://huggingface.co/datasets/PKU-Alignment/BeaverTails