### PR TITLE
Fix precision and F1 score calculations

### DIFF
--- a/guardbench/evaluate.py
+++ b/guardbench/evaluate.py
@@ -62,9 +62,9 @@ def evaluate(y_true: dict, y_pred_prob: dict, threshold: float = 0.5) -> dict:
         mcc = matthews_corrcoef(y_true, y_pred_binary)
 
     return {
-        "precision": float(precision) if n > 0 else 0.0,
+        "precision": float(precision),
         "recall": float(recall),
-        "f1": float(f1) if n > 0 else 0.0,
+        "f1": float(f1),
         "mcc": float(mcc) if n > 0 else 0.0,
         "auprc": float(auprc) if n > 0 else 0.0,
         "sensitivity": float(sensitivity),


### PR DESCRIPTION
I think that the guard `if n > 0 else 0.0` might be wrong here because precision and F1 metrics are well-defined for tests which don't have any "negative" samples. 

Running the current tutorial code from https://github.com/AmenRa/GuardBench/blob/main/docs/llama_guard.md results with the following table: 
```bash
2026-01-08 at 21:25:07 | GuardBench | INFO     | Results:
| Dataset                  | F1    | Recall   |
|--------------------------|-------|----------|
| AdvBench Behaviors       | 0.000 | 0.837    |
| AdvBench Strings         | 0.000 | 0.808    |
| BeaverTails 330k         | 0.685 | 0.545    |
| Bot-Adversarial Dialogue | 0.634 | 0.729    |
2026-01-08 at 21:25:07 | GuardBench | SUCCESS  | Done
```
Notice `0.0` for `AdvBench Behaviors/Strings`. This is coming due to the fact that these tests have only positive samples.

After the fix in this PR, the table looks as expected and showcased in your tutorial at https://github.com/AmenRa/GuardBench/blob/main/docs/llama_guard.md
```bash
2026-01-08 at 22:25:07 | GuardBench | INFO     | Results:
| Dataset                  | F1    | Recall   |
|--------------------------|-------|----------|
| AdvBench Behaviors       | 0.911 | 0.837    |
| AdvBench Strings         | 0.894 | 0.808    |
| BeaverTails 330k         | 0.685 | 0.545    |
| Bot-Adversarial Dialogue | 0.634 | 0.729    |
2026-01-08 at 21:25:07 | GuardBench | SUCCESS  | Done
```
